### PR TITLE
Update travis to use Qt 5.9 for compiling (#1141)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,16 @@ addons:
   apt:
     sources:
     - sourceline: 'ppa:beineri/opt-qt562-trusty'
+    - sourceline: 'ppa:beineri/opt-qt59-trusty'
     - sourceline: 'ppa:ubuntu-toolchain-r/test'
     packages:
     - qt56base
     - qt56multimedia
     - qt56tools
+    - qt59base
+    - qt59multimedia
+    - qt59tools
+    - qt59gamepad
     - libhunspell-dev
     - lua5.1
     - liblua5.1-0-dev
@@ -28,17 +33,25 @@ compiler:
 env:
   matrix:
   - Q_OR_C_MAKE=cmake
+    QT_VERSION=59 # actually 5.9
   - Q_OR_C_MAKE=qmake
+    QT_VERSION=59 # actually 5.9
   global:
   - secure: VFI3UCiDrp47WTcUhsatdQvvWg+3gk00eBMZgSOXXKY5+hk+NOX7bOFcIM5t9nlZDbpHDr10SFTuUOw+PeWmLpFO06Zrjg86M9jm9WS4i8Cs9hfxoT6H4isXlR1vubX2LmNlHyzg8WtdNanlsufgecyaGksJxr7tVhG/cWyD6yo=
 matrix:
   exclude:
   - os: osx
     compiler: gcc
+  include:
+  - os: linux
+    compiler: gcc
+    env: 
+    - Q_OR_C_MAKE=cmake
+    - QT_VERSION=56 # actually 5.6
 before_install:
   # add to the path here to pick up things as soon as its installed
   - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then export PATH="${HOME}/latest-gcc-symlinks:$PATH"; fi
-  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then source /opt/qt56/bin/qt56-env.sh; fi
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then source "/opt/qt${QT_VERSION}/bin/qt${QT_VERSION}-env.sh"; fi
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then PATH="/usr/local/opt/qt5/bin:$PATH"; fi
   - ./CI/travis.before_install.sh
 install: ./CI/travis.install.sh

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -323,6 +323,8 @@ ENDIF()
 FIND_PACKAGE(Qt5Core REQUIRED)
 IF (Qt5Core_VERSION VERSION_LESS 5.6)
   message(FATAL_ERROR "Mudlet requires Qt 5.6 or later")
+ELSE()
+  message(STATUS "Qt version: ${Qt5Core_VERSION}")
 ENDIF()
 
 FIND_PACKAGE(Qt5Multimedia REQUIRED)


### PR DESCRIPTION
* Re-add single QT 5.6 build job

Since we want to keep sure that the minimal Qt version is still compilable (currently we need at least 5.6), we add a single job for that version.