### PR TITLE
Improve: make minimum word length for spell-checking adjustable

### DIFF
--- a/src/Host.h
+++ b/src/Host.h
@@ -4,7 +4,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2015-2020, 2022 by Stephen Lyons                        *
+ *   Copyright (C) 2015-2020, 2022-2023 by Stephen Lyons                   *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2016 by Ian Adkins - ieadkins@gmail.com                 *
  *   Copyright (C) 2018 by Huadong Qi - novload@outlook.com                *
@@ -674,6 +674,9 @@ public:
     Q_ENUM(CaretShortcut)
     // shortcut to switch between the input line and the main window
     CaretShortcut mCaretShortcut = CaretShortcut::None;
+    // How many graphemes do we need before we run the spell checker on a
+    // "word" in the command line:
+    int mSpellCheckMinGraphemeLength = 3;
 
 signals:
     // Tells TTextEdit instances for this profile how to draw the ambiguous

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2012 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2018-2020, 2022 by Stephen Lyons                        *
+ *   Copyright (C) 2018-2020, 2022-2023 by Stephen Lyons                   *
  *                                               - slysven@virginmedia.com *
  *   Copyright (C) 2023 by Lecker Kebap - Leris@mudlet.org                 *
  *                                                                         *
@@ -663,12 +663,13 @@ void TCommandLine::slot_popupMenu()
     spellCheck();
 }
 
-void TCommandLine::fillSpellCheckList(QMouseEvent* event, QMenu* popup) {
+void TCommandLine::fillSpellCheckList(QMouseEvent* event, QMenu* popup)
+{
     QTextCursor c = cursorForPosition(event->pos());
     c.select(QTextCursor::WordUnderCursor);
     mSpellCheckedWord = c.selectedText();
 
-    if (bool IsWordLongEnoughForSpellCheck = mSpellCheckedWord.size() > 2; !IsWordLongEnoughForSpellCheck) {
+    if (bool IsWordLongEnoughForSpellCheck = (TBuffer::lengthInGraphemes(mSpellCheckedWord) >= mpHost->mSpellCheckMinGraphemeLength); !IsWordLongEnoughForSpellCheck) {
         return;
     }
 

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -261,8 +261,11 @@ bool TCommandLine::event(QEvent* event)
                 mTabCompletionCount = -1;
                 mAutoCompletionCount = -1;
                 mLastCompletion.clear();
+                // This does the actual deletion of the character:
                 QPlainTextEdit::event(event);
 
+                // Recheck spelling of shortened word
+                spellCheck();
                 adjustHeight();
                 return true;
             }
@@ -287,7 +290,11 @@ bool TCommandLine::event(QEvent* event)
                 mAutoCompletionCount = -1;
                 mTabCompletionCount = -1;
                 mLastCompletion.clear();
+                // This does the actual deletion of the character:
                 QPlainTextEdit::event(event);
+
+                // Recheck spelling of shortened word
+                spellCheck();
                 adjustHeight();
                 return true;
             }

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -2,7 +2,7 @@
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
  *   Copyright (C) 2016-2017 by Ian Adkins - ieadkins@gmail.com            *
- *   Copyright (C) 2017-2022 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2017-2023 by Stephen Lyons - slysven@virginmedia.com    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -474,6 +474,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("blankLineBehaviour") = QMetaEnum::fromType<Host::BlankLineBehaviour>().valueToKey(
             static_cast<int>(pHost->mBlankLineBehaviour));
     host.append_attribute("NetworkPacketTimeout") = pHost->mTelnet.getPostingTimeout();
+    host.append_attribute("SpellCheckMinGraphemeLength") = QString::number(pHost->mSpellCheckMinGraphemeLength).toLatin1().constData();
     if (int mode = static_cast<int>(pHost->getControlCharacterMode()); mode) {
         // Don't bother to include the attribute if it is the default (zero)
         // value - and as it is an ASCII digit it only needs

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  *   Copyright (C) 2008-2013 by Heiko Koehn - KoehnHeiko@googlemail.com    *
  *   Copyright (C) 2014 by Ahmed Charles - acharles@outlook.com            *
- *   Copyright (C) 2016-2022 by Stephen Lyons - slysven@virginmedia.com    *
+ *   Copyright (C) 2016-2023 by Stephen Lyons - slysven@virginmedia.com    *
  *   Copyright (C) 2016-2017 by Ian Adkins - ieadkins@gmail.com            *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -941,6 +941,15 @@ void XMLimport::readHost(Host* pHost)
     } else {
         // The default (and for map/profile files from before 4.15.0):
         pHost->setLargeAreaExitArrows(false);
+    }
+
+    if (attributes().hasAttribute(QLatin1String("SpellCheckMinGraphemeLength"))) {
+        // These limits are also hard coded into the QSpinBox used to adjust
+        // this setting in the preferences:
+        pHost->mSpellCheckMinGraphemeLength = qBound(1, attributes().value(qsl("SpellCheckMinGraphemeLength")).toInt(), 9);
+    } else {
+        // The default value, but not present up to around Mudlet 4.17.0:
+        pHost->mSpellCheckMinGraphemeLength = 3;
     }
 
     if (attributes().value(qsl("mShowInfo")) == qsl("no")) {

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -408,6 +408,8 @@ void dlgProfilePreferences::disableHostDetails()
     groupBox_input->setEnabled(false);
 
     groupBox_spellCheck->setEnabled(false);
+    // This is the default value used for Host::mSpellCheckMinGraphemeLength:
+    spinBox_minimumLengthToSpellCheck->setValue(3);
 
     // ===== tab_display =====
     groupBox_font->setEnabled(false);
@@ -668,6 +670,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
         checkBox_spellCheck->setText(tr("System dictionaries:", "On *nix systems where we find the system ones we use them."));
     }
 
+    spinBox_minimumLengthToSpellCheck->setValue(pHost->mSpellCheckMinGraphemeLength);
     QDir dir(path);
     QStringList entries = dir.entryList(QDir::Files, QDir::Time);
     // QRegularExpression rex(qsl(R"(\.dic$)"));
@@ -2628,6 +2631,7 @@ void dlgProfilePreferences::slot_saveAndClose()
         } else {
             pHost->setUserDictionaryOptions(true, false);
         }
+        pHost->mSpellCheckMinGraphemeLength = spinBox_minimumLengthToSpellCheck->value();
         pHost->mWrapAt = wrap_at_spinBox->value();
         pHost->updateDisplayDimensions();
         pHost->mWrapIndentCount = indent_wrapped_spinBox->value();

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -607,8 +607,8 @@
          <property name="title">
           <string>Spell checking</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_groupBox_spellCheck">
-          <item>
+         <layout class="QGridLayout" name="gridLayout_groupBox_spellCheck">
+          <item row="0" column="0">
            <widget class="QCheckBox" name="checkBox_spellCheck">
             <property name="toolTip">
              <string>&lt;p&gt;This option controls spell-checking on the command line in the main console for this profile.&lt;/p&gt;</string>
@@ -618,7 +618,7 @@
             </property>
            </widget>
           </item>
-          <item>
+          <item row="1" column="0" colspan="2">
            <widget class="QListWidget" name="dictList">
             <property name="toolTip">
              <string>&lt;p&gt;Select one dictionary which will be available on the command line and in the lua sub-system.&lt;/p&gt;</string>
@@ -646,7 +646,7 @@
             </property>
            </widget>
           </item>
-          <item>
+          <item row="2" column="0" colspan="2">
            <widget class="QGroupBox" name="groupBox_userDictionary">
             <property name="title">
              <string>User dictionary:</string>
@@ -673,6 +673,29 @@
               </widget>
              </item>
             </layout>
+           </widget>
+          </item>
+          <item row="3" column="0" alignment="Qt::AlignRight">
+           <widget class="QLabel" name="label_minimumLengthToSpellCheck">
+            <property name="text">
+             <string>Minimum length of word to spell-check:</string>
+            </property>
+            <property name="buddy">
+             <cstring>spinBox_minimumLengthToSpellCheck</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1" alignment="Qt::AlignLeft">
+           <widget class="QSpinBox" name="spinBox_minimumLengthToSpellCheck">
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>9</number>
+            </property>
+            <property name="value">
+             <number>3</number>
+            </property>
            </widget>
           </item>
          </layout>
@@ -3376,11 +3399,11 @@ you can use it but there could be issues with aligning columns of text</string>
        </item>
        <item>
         <widget class="QCheckBox" name="checkBox_askTlsAvailable">
+         <property name="toolTip">
+          <string>&lt;p&gt;To encourage enhanced data transfer protection and privacy, be prompted for a choice to switch to an encrypted port when advertised via Mud Server Status Protocol (MSSP).&lt;/p&gt;</string>
+         </property>
          <property name="text">
           <string>Allow secure connection reminder</string>
-         </property>
-         <property name="toolTip">
-           <string>&lt;p&gt;To encourage enhanced data transfer protection and privacy, be prompted for a choice to switch to an encrypted port when advertised via Mud Server Status Protocol (MSSP).&lt;/p&gt;</string>
          </property>
          <property name="checkable">
           <bool>true</bool>
@@ -4063,6 +4086,7 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>dictList</tabstop>
   <tabstop>radioButton_userDictionary_profile</tabstop>
   <tabstop>radioButton_userDictionary_common</tabstop>
+  <tabstop>spinBox_minimumLengthToSpellCheck</tabstop>
   <tabstop>fontComboBox</tabstop>
   <tabstop>mNoAntiAlias</tabstop>
   <tabstop>fontSize</tabstop>
@@ -4183,6 +4207,7 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>checkBox_mUSE_FORCE_LF_AFTER_PROMPT</tabstop>
   <tabstop>mFORCE_MXP_NEGOTIATION_OFF</tabstop>
   <tabstop>checkbox_noAutomaticUpdates</tabstop>
+  <tabstop>buttonPurgeMediaCache</tabstop>
   <tabstop>search_engine_combobox</tabstop>
   <tabstop>checkBox_showIconsOnMenus</tabstop>
   <tabstop>checkBox_debugShowAllCodepointProblems</tabstop>
@@ -4190,6 +4215,9 @@ you can use it but there could be issues with aligning columns of text</string>
   <tabstop>comboBox_store_passwords_in</tabstop>
   <tabstop>timeEdit_timerDebugOutputMinimumInterval</tabstop>
   <tabstop>doubleSpinBox_networkPacketTimeout</tabstop>
+  <tabstop>checkBox_announceIncomingText</tabstop>
+  <tabstop>comboBox_blankLinesBehaviour</tabstop>
+  <tabstop>comboBox_caretModeKey</tabstop>
  </tabstops>
  <resources>
   <include location="../mudlet.qrc"/>


### PR DESCRIPTION
Also modify it to use the number of graphemes ("visual text" units)
rather than the number of `QChar`s in the `QString` - this avoids
complications about measuring the "word length" when the text is encoded
in a *variable length encoding* (a `QString` is encoded in UTF-16BE form).

The setting is saved/loaded on a per-profile basis in the game save file.

Revised to also make the spell-check underlining respect the spell-check limit

Fix a bug I spotted in the existing (prior to @Leris/@Kebap s PR) code
whilst trying to debug his work to determine why the previous commit to
clear the underlines from "too short" words was not working when characters
were deleted!

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>