### PR TITLE
Improve: Don't start Tutorial on every Localhost connection

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -6169,19 +6169,22 @@ void mudlet::refreshTabBar()
 
 //NOLINT(readability-convert-member-functions-to-static)
 // doesn't make sense to make it static since it modifies a class variable
-void mudlet::setupPreInstallPackages(const QString& gameUrl)
+void mudlet::setupPreInstallPackages(const QString& gameUrl, const QString& profileName)
 {
     const QHash<QString, QStringList> defaultScripts = {
         // clang-format off
         // scripts to pre-install for a profile      games this applies to, * means all games
         {qsl(":/run-lua-code.mpackage"),             {qsl("*")}},
-        {qsl(":/echo.mpackage"),                          {qsl("*")}},
-        {qsl(":/deleteOldProfiles.mpackage"),             {qsl("*")}},
-        {qsl(":/enable-accessibility.mpackage"), {qsl("*")}},
-        {qsl(":/mpkg.mpackage"),                    {qsl("*")}},
+        {qsl(":/echo.mpackage"),                     {qsl("*")}},
+        {qsl(":/deleteOldProfiles.mpackage"),        {qsl("*")}},
+        {qsl(":/enable-accessibility.mpackage"),     {qsl("*")}},
+        {qsl(":/mpkg.mpackage"),                     {qsl("*")}},
         {qsl(":/mudlet-lua/lua/gui-drop/gui-drop.mpackage"), {qsl("*")}},
         {qsl(":/CF-loader.xml"),                     {qsl("carrionfields.net")}},
-        {qsl(":/mg-loader.xml"),                     {qsl("mg.mud.de")}},
+        {qsl(":/mg-loader.xml"),                     {qsl("mg.mud.de"),
+                                                      qsl("mud.morgengrauen.info"),
+                                                      qsl("mg.morgengrauen.info"),
+                                                      qsl("morgengrauen.info")}},
         {qsl(":/run-tests.xml"),                     {qsl("mudlet.org")}},
         {qsl(":/mudlet-lua/lua/stressinator/StressinatorDisplayBench.xml"), {qsl("mudlet.org")}},
         {qsl(":/mudlet-mapper.xml"),                 {qsl("aetolia.com"),
@@ -6204,6 +6207,11 @@ void mudlet::setupPreInstallPackages(const QString& gameUrl)
 
     if (!mudlet::self()->mPackagesToInstallList.contains(qsl(":/mudlet-mapper.xml"))) {
         mudlet::self()->mPackagesToInstallList.append(qsl(":/mudlet-lua/lua/generic-mapper/generic_mapper.mpackage"));
+    }
+
+    // Don't play tutorial for every connection to localhost. There are legit other reasons to connect there.
+    if (profileName == qsl("Mudlet Tutorial") && gameURL == qsl("localhost")) {
+        mudlet::self()->mPackagesToInstallList.append(qsl(":/mudlet-tutorial.mpackage");
     }
 }
 

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -314,7 +314,7 @@ public:
     void setShowMapAuditErrors(const bool);
     void setInvertMapZoom(const bool);
     void setShowTabConnectionIndicators(const bool);
-    void setupPreInstallPackages(const QString&);
+    void setupPreInstallPackages(const QString&, const QString&);
     void setToolBarIconSize(int);
     void setToolBarVisibility(enums::controlsVisibility);
     void showChangelogIfUpdated();


### PR DESCRIPTION
#### Brief overview of PR changes/additions

Only start Tutorial for the profile called "Mudlet Tutorial" and not on every connection to localhost anymore

#### Motivation for adding to Mudlet

There are legit other reasons to connect to localhost. There are no ways to stop a tutorial. See bug report for details.

#### Other info (issues closed, discussion etc)

Fix #8234
Help #8188 
