### PR TITLE
Fix: Improve translation-friendliness of UI strings

### DIFF
--- a/src/mapInfoContributorManager.cpp
+++ b/src/mapInfoContributorManager.cpp
@@ -1,5 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2021 by Piotr Wilczynski - delwing@gmail.com            *
+ *   Copyright (C) 2023 by Lecker Kebap - Leris@mudlet.org                 *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -119,11 +120,12 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
         if (area) {
             infoText = qsl("%1\n").arg(
                 /*:
+                %1 is the (text) name of the area, %2 is the area ID number,
+                %3 and %4 are the minimum and maximum x coordinates, %5 and %6 for y, and %7 and %8 for z.
                 This text uses non-breaking spaces (Unicode U+00A0) and non-breaking hyphens
                 which are used to prevent the line being split at some places it might otherwise be.
                 When translating, please consider at which points the text may be divided to fit
-                onto more than one line. %1 is the (text) name of the area, %2 is the area ID number,
-                %3 and %4 are the minimum and maximum x coordinates, %5 and %6 for y, and %7 and %8 for z.
+                onto more than one line. 
                 */
                            tr("Area:\u00A0%1 ID:\u00A0%2 x:\u00A0%3\u00A0<‑>\u00A0%4 y:\u00A0%5\u00A0<‑>\u00A0%6 z:\u00A0%7\u00A0<‑>\u00A0%8")
                                .arg(areaName,
@@ -155,11 +157,12 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
         case 0:
             infoText.append(qsl("%1\n").arg(
                 /*:
+                This text is shown when NO rooms are selected: %1 is the room ID number,
+                and %2, %3, %4 are the x, y, and z coordinates for the current player's room.
                 This text uses non-breaking spaces (Unicode U+00A0) and a non-breaking hyphen which
                 are used to prevent the line being split at some places it might otherwise be.
                 When translating, please consider at which points the text may be divided to fit onto
-                more than one line. This text is for when NO rooms are selected: %1 is the room ID number,
-                and %2, %3, %4 are the x, y, and z coordinates for the current player's room.
+                more than one line. 
                 */
                                tr("Room\u00A0ID:\u00A0%1 Position\u00A0on\u00A0Map: (%2,%3,%4) ‑\u00A0current player location")
                                     .arg(QString::number(roomID),
@@ -175,11 +178,12 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
         case 1:
             infoText.append(qsl("%1\n").arg(
                 /*:
+                This text is shown when ONE room is selected: %1 is the room ID number,
+                and %2, %3, %4 are the x, y, and z coordinates for the selected room.
                 This text uses non-breaking spaces (Unicode U+00A0) and a non-breaking hyphen which
                 are used to prevent the line being split at some places it might otherwise be.
                 When translating, please consider at which points the text may be divided to fit onto
-                more than one line. This text is for when ONE room is selected: %1 is the room ID number,
-                and %2, %3, %4 are the x, y, and z coordinates for the selected room.
+                more than one line. 
                 */
                                tr("Room\u00A0ID:\u00A0%1 Position\u00A0on\u00A0Map: (%2,%3,%4) ‑\u00A0selected room")
                                     .arg(QString::number(roomID),
@@ -196,20 +200,22 @@ MapInfoProperties MapInfoContributorManager::fullInfo(int roomID, int selectionS
         default:
             infoText.append(qsl("%1\n").arg(
                 /*:
+                This text is shown when MORE THAN ONE room is selected. %1 is the room
+                ID number for which %2, %3, %4 are the x, y, and z coordinates of the room nearest the
+                middle of the selection. This room has the yellow cross-hairs. %5 is a description like:
+                center of 8 selected rooms.
                 This text uses non-breaking spaces (Unicode U+00A0) and a non-breaking hyphen which
                 are used to prevent the line being split at some places it might otherwise be.
                 When translating, please consider at which points the text may be divided to fit onto
-                more than one line. This text is for when TWO or MORE rooms are selected: %1 is the room
-                ID number for which %2, %3, %4 are the x, y, and z coordinates of the room nearest the
-                middle of the selection. This room has the yellow cross-hairs. %n is the count of rooms
-                selected and will ALWAYS be greater than 1 in this situation. It is provided so that
-                non-English translations can select required plural forms as needed.
+                more than one line.
                 */
-                               tr("Room\u00A0ID:\u00A0%1 Position\u00A0on\u00A0Map: (%2,%3,%4) ‑\u00A0center of %n selected rooms", nullptr, selectionSize)
+                               tr("Room\u00A0ID:\u00A0%1 Position\u00A0on\u00A0Map: (%2,%3,%4) ‑\u00A0%5")
                                     .arg(QString::number(roomID),
                                         QString::number(room->x()),
                                         QString::number(room->y()),
-                                        QString::number(room->z()))));
+                                        QString::number(room->z()),
+                /*: This text is shown when MORE THAN ONE room is selected. */
+                                        tr("center of %n selected rooms", nullptr, selectionSize))));
             isBold = true;
             if (infoColor.lightness() > 127) {
                 color = QColor(255, 223, 191); // Slightly orange white


### PR DESCRIPTION
#### Brief overview of PR changes/additions
Remove sentence starting with "center" and no space character from after Unicode char, move to own translation unit.

#### Motivation for adding to Mudlet
Crowdin displayed characters wrong ("mojibake") Translators got confused if this string is meant to be that way at all.

#### Other info (issues closed, discussion etc)
Follow up to #8415