### PR TITLE
Infra: Improve documentation to hide ui strings from translation

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -50,6 +50,7 @@ QString displayText = tr("Connection failed: %1").arg(errorMessage);
 
 * minimise use of HTML styling tags in strings to be translated
 * enable users to use language-specific Mudlet object names (triggers, aliases, labels, etc)
+* .ui files are always enabled for translation. To disable a string, use notr: `<string notr="true">text</string>`
 
 Don't:
 * translate the Mudlet API: functions, events, error messages or constants (e.g. `main` console)


### PR DESCRIPTION
#### Brief overview of PR changes/additions
- Document the a bit arcane "notr" option in .ui files

#### Motivation for adding to Mudlet
- some UI text do not need translation after all

#### Other info (issues closed, discussion etc)
- Was searching for this option quite a while 